### PR TITLE
[Bug fixed] Packages are checked before installing

### DIFF
--- a/lib/install_base.sh
+++ b/lib/install_base.sh
@@ -35,6 +35,13 @@ install_base() {
         height="16"
     fi
 
+    # Remove packages that disappear from official repositories
+	for package in "${base_install[@]}"; do 
+		if [ $(pacman -Ssq "$package" | grep -q "^$package" ; echo $?) -ne 0 ]; then
+			base_install=("${base_install[@]/$package}")
+		fi
+	done
+    
     until "$INSTALLED"
       do
         if (dialog --yes-button "$install" --no-button "$cancel" --yesno "\n$install_var" "$height" 65); then


### PR DESCRIPTION
The bug that caused the installation process to abort when it found that a package no longer existed within the official repositories is resolved. Package by package is now checked before installation begins. If it does not exist, it is discarded.

Solve #845 

