### PR TITLE
Improved "auto_part" for btrfs

### DIFF
--- a/etc/anarchy.conf
+++ b/etc/anarchy.conf
@@ -73,7 +73,6 @@ config() {
     # Log and tmp files
     log=/tmp/anarchy.log
     tmp_menu=/tmp/anarchy/part.sh
-    tmp_menu=/tmp/anarchy/part.sh
     tmp_list=/tmp/anarchy/part.list
     tmp_passwd=/tmp/anarchy/passwd
 

--- a/lib/configure_device.sh
+++ b/lib/configure_device.sh
@@ -257,6 +257,7 @@ auto_part() {
 
     (mount /dev/"$ROOT" "$ARCH"
     echo "$?" > /tmp/ex_status.var
+    btrfs_subvol
     mkdir $ARCH/boot
     mount /dev/"$BOOT" "$ARCH"/boot) &> /dev/null &
     pid=$! pri=0.1 msg="\n$mnt_load \n\n \Z1> \Z2mount /dev/$ROOT $ARCH\Zn" load
@@ -269,6 +270,29 @@ auto_part() {
 
     rm /tmp/ex_status.var
 
+}
+
+btrfs_subvol() {
+    btrfs subvolume create "$ARCH"/@
+    btrfs subvolume create "$ARCH"/@home
+    btrfs subvolume create "$ARCH"/@snapshots
+    btrfs subvolume create "$ARCH"/@homeshots
+
+    umount "$ARCH"
+
+    if [[ "$f2fs" -eq "0" ]]; then
+        o_btrfs="compress,ssd,discard"
+    else
+        o_btrfs="compress"
+    fi
+
+    mount -o subvol=@,$o_btrfs "$ROOT" "$ARCH"
+    mkdir /mnt/{home,.snapshots}
+
+    mount -o subvol=@home,$o_btrfs "$ROOT" "$ARCH"/home
+    mount -o subvol=@snapshots,$o_btrfs "$ROOT" "$ARCH"/.snapshots
+    mkdir "$ARCH"/home/.snapshots
+    mount -o subvol=@homeshots,$o_btrfs "$ROOT" "$ARCH"/home/.snapshots
 }
 
 auto_encrypt() {

--- a/lib/configure_device.sh
+++ b/lib/configure_device.sh
@@ -286,13 +286,13 @@ btrfs_subvol() {
         o_btrfs="compress"
     fi
 
-    mount -o subvol=@,$o_btrfs "$ROOT" "$ARCH"
+    mount -o subvol=@,$o_btrfs /dev/"$ROOT" "$ARCH"
     mkdir /mnt/{home,.snapshots}
 
-    mount -o subvol=@home,$o_btrfs "$ROOT" "$ARCH"/home
-    mount -o subvol=@snapshots,$o_btrfs "$ROOT" "$ARCH"/.snapshots
+    mount -o subvol=@home,$o_btrfs /dev/"$ROOT" "$ARCH"/home
+    mount -o subvol=@snapshots,$o_btrfs /dev/"$ROOT" "$ARCH"/.snapshots
     mkdir "$ARCH"/home/.snapshots
-    mount -o subvol=@homeshots,$o_btrfs "$ROOT" "$ARCH"/home/.snapshots
+    mount -o subvol=@homeshots,$o_btrfs /dev/"$ROOT" "$ARCH"/home/.snapshots
 }
 
 auto_encrypt() {

--- a/lib/configure_user.sh
+++ b/lib/configure_user.sh
@@ -278,10 +278,10 @@ add_user() {
 
     if "$menu_enter" ; then
         if [ "$full_user" == "" ]; then
-            arch-chroot "$ARCH" useradd -m -G audio,network,power,storage,optical -s "$sh" "$user" &>/dev/null &
+            arch-chroot "$ARCH" useradd -m -g users -G audio,network,power,storage,optical -s "$sh" "$user" &>/dev/null &
                     pid=$! pri=0.1 msg="$wait_load \n\n \Z1> \Z2useradd $user\Zn" load
             else
-                    arch-chroot "$ARCH" useradd -m -G audio,network,power,storage,optical -c "$full_name" -s "$sh" "$user" &>/dev/null &
+                    arch-chroot "$ARCH" useradd -m -g users -G audio,network,power,storage,optical -c "$full_name" -s "$sh" "$user" &>/dev/null &
                     pid=$! pri=0.1 msg="$wait_load \n\n \Z1> \Z2useradd $user\Zn" load
             fi
 
@@ -299,10 +299,10 @@ add_user() {
     else
         while IFS= read -r i ; do
                      if [ "$(<<<"$i" cut -d: -f4)" == "" ]; then
-                             arch-chroot "$ARCH" useradd -m -G audio,network,power,storage,optical -s "$(<<<"$i" cut -d: -f2)" "$(<<<"$i" cut -d: -f1)" &>/dev/null &
+                             arch-chroot "$ARCH" useradd -m -g users -G audio,network,power,storage,optical -s "$(<<<"$i" cut -d: -f2)" "$(<<<"$i" cut -d: -f1)" &>/dev/null &
                              pid=$! pri=0.1 msg="$wait_load \n\n \Z1> \Z2useradd $(<<<"$i" cut -d: -f1)\Zn" load
                      else
-                             arch-chroot "$ARCH" useradd -m -G audio,network,power,storage,optical -c "$(<<<"$i" cut -d: -f4)" -s "$(<<<"$i" cut -d: -f2)" "$(<<<"$i" cut -d: -f1)" &>/dev/null &
+                             arch-chroot "$ARCH" useradd -m -g users -G audio,network,power,storage,optical -c "$(<<<"$i" cut -d: -f4)" -s "$(<<<"$i" cut -d: -f2)" "$(<<<"$i" cut -d: -f1)" &>/dev/null &
                              pid=$! pri=0.1 msg="$wait_load \n\n \Z1> \Z2useradd $(<<<"$i" cut -d: -f1)\Zn" load
                      fi
 

--- a/lib/configure_user.sh
+++ b/lib/configure_user.sh
@@ -278,10 +278,10 @@ add_user() {
 
     if "$menu_enter" ; then
         if [ "$full_user" == "" ]; then
-            arch-chroot "$ARCH" useradd -m -g users -G audio,network,power,storage,optical -s "$sh" "$user" &>/dev/null &
+            arch-chroot "$ARCH" useradd -m -G audio,network,power,storage,optical -s "$sh" "$user" &>/dev/null &
                     pid=$! pri=0.1 msg="$wait_load \n\n \Z1> \Z2useradd $user\Zn" load
             else
-                    arch-chroot "$ARCH" useradd -m -g users -G audio,network,power,storage,optical -c "$full_name" -s "$sh" "$user" &>/dev/null &
+                    arch-chroot "$ARCH" useradd -m -G audio,network,power,storage,optical -c "$full_name" -s "$sh" "$user" &>/dev/null &
                     pid=$! pri=0.1 msg="$wait_load \n\n \Z1> \Z2useradd $user\Zn" load
             fi
 
@@ -299,10 +299,10 @@ add_user() {
     else
         while IFS= read -r i ; do
                      if [ "$(<<<"$i" cut -d: -f4)" == "" ]; then
-                             arch-chroot "$ARCH" useradd -m -g users -G audio,network,power,storage,optical -s "$(<<<"$i" cut -d: -f2)" "$(<<<"$i" cut -d: -f1)" &>/dev/null &
+                             arch-chroot "$ARCH" useradd -m -G audio,network,power,storage,optical -s "$(<<<"$i" cut -d: -f2)" "$(<<<"$i" cut -d: -f1)" &>/dev/null &
                              pid=$! pri=0.1 msg="$wait_load \n\n \Z1> \Z2useradd $(<<<"$i" cut -d: -f1)\Zn" load
                      else
-                             arch-chroot "$ARCH" useradd -m -g users -G audio,network,power,storage,optical -c "$(<<<"$i" cut -d: -f4)" -s "$(<<<"$i" cut -d: -f2)" "$(<<<"$i" cut -d: -f1)" &>/dev/null &
+                             arch-chroot "$ARCH" useradd -m -G audio,network,power,storage,optical -c "$(<<<"$i" cut -d: -f4)" -s "$(<<<"$i" cut -d: -f2)" "$(<<<"$i" cut -d: -f1)" &>/dev/null &
                              pid=$! pri=0.1 msg="$wait_load \n\n \Z1> \Z2useradd $(<<<"$i" cut -d: -f1)\Zn" load
                      fi
 


### PR DESCRIPTION
<!--
This is a comment, which will not show up in your pull request, so you don't need to remove it.
Write all your text below the comments or delete them if you want.
-->

## Description

<!-- An in-depth description of what your pull request does. -->
Added a new function in "configure_device.sh" called "btrfs_subvol" that creates btrfs subvolumes if the user chooses auto_part + btrfs.

Layout is basically https://wiki.archlinux.org/index.php/Snapper#Suggested_filesystem_layout
subvols: @, @home, @snapshots, @homeshots

## Affected issues

<!-- Tag any relevant issues your PR closes by prepending their number with a # (e.g. "Closes #123"). -->
None. But the way btrfs is handled currently makes no sense.

## TODO

- include swapfile on btrfs instead of partition
- enable encryption-option
- improve manual partitioning => add ability to mount btrfs subvols to the correct places
**- improve layout? Please comment on that, we can swap to the way opensuse does it for example.**

## Pull request checklist

<!-- Please check off as many of these as possible prior to submitting a pull request (if you actually did them).
Put an 'x' between the square brackets to tick the field. -->

* [ ] I have tested my code
* [ ] I have read the [contributing guide](https://github.com/AnarchyLinux/installer/blob/HEAD/CONTRIBUTING.md)
* [ ] I have followed best practices and commented my code well