### PR TITLE
Updated README.md to use oflag=sync the behavior is more predictable …

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ DON'T COPY AND PASTE THE TEXT BELOW AS ANY DISK YOU SELECT WILL BE COMPLETELY WI
 Replace `x` with your USB device's letter (use `lsblk` to check which letter it was assigned, usually it's "b"):
 
 ```
-sudo dd if=./<anarchy-image.iso> of=/dev/sdx bs=4M status=progress && sync
+sudo dd if=./<anarchy-image.iso> of=/dev/sdx bs=4M status=progress oflag=sync
 ```
 
 You can also use GUI based software such as [Etcher](https://www.balena.io/etcher/).


### PR DESCRIPTION
## Description

This seems a little nit picky, but the progress is more responsive by changing the `dd` command. From the man page
```
oflag=FLAGS
        write as per the comma separated symbol list
...skipping to symbol list...
dsync  use synchronized I/O for data
sync   likewise, but also for metadata
```
I only noticed since I rewrote that line of the [wiki](https://wiki.archlinux.org/index.php?title=USB_flash_installation_media&diff=prev&oldid=506780) 

## Affected issues

None

## Pull request checklist

- [x] I have tested my code
- [x] I have read the [contributing guide](https://github.com/AnarchyLinux/installer/blob/HEAD/CONTRIBUTING.md)
- [x] I have followed best practices and commented my code well