### PR TITLE
keep arch-release file for compatibility reasons

### DIFF
--- a/lib/configure_system.sh
+++ b/lib/configure_system.sh
@@ -303,7 +303,7 @@ configure_system() {
     cp "${anarchy_directory}"/extra/.bashrc "$ARCH"/etc/skel/
     (cp /etc/lsb-release "$ARCH"/etc
     cp /etc/os-release "$ARCH"/etc
-    mv "$ARCH"/etc/arch-release "$ARCH"/etc/anarchy-release) &>/dev/null
+    cp "$ARCH"/etc/arch-release "$ARCH"/etc/anarchy-release) &>/dev/null
 
     sed -i 's/^#Color$/Color/' "$ARCH"/etc/pacman.conf
     sed -i 's/^#TotalDownload$/TotalDownload/' "$ARCH"/etc/pacman.conf


### PR DESCRIPTION
This is a minor change, and also a suggestion. :)

## What has changed?

Rather than `mv`'ing the `/etc/arch-release`, we `cp` it instead.

## Why might this be a good idea?

After using the Anarchy Installer I've noticed that there are some scripts (for example: [the `fzf` `oh-my-zsh` plugin](https://github.com/ohmyzsh/ohmyzsh/blob/e204c596ef5a1075914c5e7810ec1eba4bbe7411/plugins/fzf/fzf.plugin.zsh#L35)) fail to recognise my installation as an Arch Linux distribution.

I think that rather than moving the file, we could copy it instead so anything that checks for `/etc/arch-release` doesn't break if we've installed the distribution via Anarchy - and we also get to keep the `/etc/anarchy-release` file.