### PR TITLE
Changes grep expression to capture wlan interfaces

### DIFF
--- a/etc/anarchy.conf
+++ b/etc/anarchy.conf
@@ -218,7 +218,7 @@ config() {
     fi
 
     # Check for wifi network
-    wifi_network=$(ip addr | grep "wlp\|wlo" | awk '{print $2}' | sed 's/://' | head -n 1)
+    wifi_network=$(ip addr | grep "wlp\|wlo\|wlan" | awk '{print $2}' | sed 's/://' | head -n 1)
 
     if [ -n "${wifi_network}" ]; then
         wifi=true


### PR DESCRIPTION
<!--
This is a comment, which will not show up in your pull request, so you don't need to remove it.
Write all your text below the comments or delete them if you want.
-->

## Description

While I was installing anarchy last night I came across a problem with the wifi connection.

My investigation steps were:
  - I connected to wifi via `wifi-menu` and my wifi connected properly.
  - I checked `ip link` and my interface was up and working appropriately.
  - I checked that my internet was working as I could ping some domains.
  - In the very beginning of the installation I would get a connection error preventing me of continuing with the installation.
  - The installer would also throw me a connection error while doing the connection test from anarchy.
   - After doing a look in the installer repo I found out that the regex that checks for interfaces wasn't properly looking for `wlan`, which is the interface I have on my Asus Zenbook laptop
![image](https://user-images.githubusercontent.com/17491689/73399041-6b4c6b80-434b-11ea-8986-c7b5faa534d7.png)

   - I changed `/etc/anarchy.conf` during the installation with the fix in this PR and then I could proceed normally with the installation.


## Affected issues

Nothing that I could find but please feel free to edit it in here.

## Pull request checklist

<!-- Please check off as many of these as possible prior to submitting a pull request (if you actually did them).
Put an 'x' between the square brackets to tick the field. -->

* [x] I have tested my code
* [x] I have read the [contributing guide](https://github.com/AnarchyLinux/installer/blob/HEAD/CONTRIBUTING.md)
* [x] I have followed best practices and commented my code well