### PR TITLE
Added option "-k" to the initial screen

### DIFF
--- a/etc/issue_cli
+++ b/etc/issue_cli
@@ -13,8 +13,9 @@
 [0;31m |			    	                                              |
 [0;31m |[0;33m 	1.[0;31m) [0;32mAnarchy Installer       - anarchy			              [0;31m|
 [0;31m |[0;33m 	2.[0;31m) [0;32mAnarchy Update          - anarchy -u			      [0;31m|
-[0;31m |[0;33m 	3.[0;31m) [0;32mConnection Test	    - iptest				      [0;31m|
-[0;31m |[0;33m 	4.[0;31m) [0;32mSystem Information      - sysinfo				      [0;31m|
+[0;31m |[0;33m 	3.[0;31m) [0;32mUpdate Archlinux Keys   - anarchy -k			      [0;31m|
+[0;31m |[0;33m 	4.[0;31m) [0;32mConnection Test	    - iptest				      [0;31m|
+[0;31m |[0;33m 	5.[0;31m) [0;32mSystem Information      - sysinfo				      [0;31m|
 [0;31m |			    	                                              |
 [0;33m [0;31m|[0;33m For more info on Anarchy Linux type:[0;32m help[0;33m OR:[0;32m anarchy --help	              [0;31m|
 [0;33m [0;31m|[0;33m To show this screen at any time type:[0;32m start[0m		                      [0;31m|


### PR DESCRIPTION
It is a small change but I have noticed in the Anarchy group in Spanish that very few users use the `-k` option, and instead update the keys manually.
Subsequently, the help option should be improved so that it provides more information about the installation process.